### PR TITLE
Feature/22189 emneforsider automatisering

### DIFF
--- a/sites/all/themes/egedal/css/styles.css
+++ b/sites/all/themes/egedal/css/styles.css
@@ -10946,6 +10946,8 @@ html.js .ctools-collapsible-container .ctools-collapsible-handle {
 .panel-4col-25-left-stack-profile-topic-fp.panel-display .panel-row-third.row,
 .panel-4col-25-left-stack-profile-topic-fp.panel-display .panel-row-forth.row {
   display: none;
+  visibility: hidden;
+  height: 0;
 }
 
 #block-menu-block-1 ul li {


### PR DESCRIPTION
CSS fix to hide panelizer link lists in IE 11